### PR TITLE
Update rust-channel to nightly-2020-04-19

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,17 +3,17 @@ name: default
 
 steps:
 - name: build
-  image: truedoctor/rust-wasm:nightly-2020-04-19
+  image: truedoctor/rust-wasm:nightly-2020-04-19-1
   pull: if-not-exists
   commands:
   - nix-shell --run 'cargo make all' --arg inCI true # build all projects
 - name: test
-  image: truedoctor/rust-wasm:nightly-2020-04-19
+  image: truedoctor/rust-wasm:nightly-2020-04-19-1
   pull: if-not-exists
   commands:
   - nix-shell --run 'cargo make test' --arg inCI true # test all projects
 - name: doc
-  image: truedoctor/rust-wasm:nightly-2020-04-19
+  image: truedoctor/rust-wasm:nightly-2020-04-19-1
   pull: if-not-exists
   when:
     branch:
@@ -24,7 +24,7 @@ steps:
   commands:
   - nix-shell --run 'cargo doc --no-deps' --arg inCI true # document all projects
 - name: demo
-  image: truedoctor/rust-wasm:nightly-2020-04-19
+  image: truedoctor/rust-wasm:nightly-2020-04-19-1
   pull: if-not-exists
   when:
     branch:
@@ -35,7 +35,7 @@ steps:
   commands:
   - cp -r client /tmp/demo
 - name: format
-  image: truedoctor/rust-wasm:nightly-2020-04-19
+  image: truedoctor/rust-wasm:nightly-2020-04-19-1
   pull: if-not-exists
   commands:
   - nix-shell --run 'cargo make check-format' --arg inCI true # check formatting for all projects

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,17 +3,17 @@ name: default
 
 steps:
 - name: build
-  image: truedoctor/rust-wasm:nightly-2020-02-28
+  image: truedoctor/rust-wasm:nightly-2020-04-19
   pull: if-not-exists
   commands:
   - nix-shell --run 'cargo make all' --arg inCI true # build all projects
 - name: test
-  image: truedoctor/rust-wasm:nightly-2020-02-28
+  image: truedoctor/rust-wasm:nightly-2020-04-19
   pull: if-not-exists
   commands:
   - nix-shell --run 'cargo make test' --arg inCI true # test all projects
 - name: doc
-  image: truedoctor/rust-wasm:nightly-2020-02-28
+  image: truedoctor/rust-wasm:nightly-2020-04-19
   pull: if-not-exists
   when:
     branch:
@@ -24,7 +24,7 @@ steps:
   commands:
   - nix-shell --run 'cargo doc --no-deps' --arg inCI true # document all projects
 - name: demo
-  image: truedoctor/rust-wasm:nightly-2020-02-28
+  image: truedoctor/rust-wasm:nightly-2020-04-19
   pull: if-not-exists
   when:
     branch:
@@ -35,7 +35,7 @@ steps:
   commands:
   - cp -r client /tmp/demo
 - name: format
-  image: truedoctor/rust-wasm:nightly-2020-02-28
+  image: truedoctor/rust-wasm:nightly-2020-04-19
   pull: if-not-exists
   commands:
   - nix-shell --run 'cargo make check-format' --arg inCI true # check formatting for all projects

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 
 [[package]]
 name = "cfg-if"
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc5483f8d5afd3653b38a196c52294dcb239c3e1a5bade1990353ea13bcf387"
+checksum = "9117f4167a8f21fa2bb3f17a652a760acd7572645281c98e3b612a26242c96ee"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1017,9 +1017,9 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "png"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910f09135b1ed14bb16be445a8c23ddf0777eca485fbfc7cee00d81fecab158a"
+checksum = "2c68a431ed29933a4eb5709aca9800989758c97759345860fa5db3cfced0b65d"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "schannel"
@@ -1430,9 +1430,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "spin"
@@ -1582,9 +1582,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1639,12 +1639,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -1826,7 +1825,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -1974,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "wee_alloc"
 version = "0.4.5"
-source = "git+https://github.com/squirrel-labs/wee_alloc#7a241cd1b441b10251375304e6f7834a67fb54c7"
+source = "git+https://github.com/Ma27/wee_alloc?branch=nightly#0f9954eddcbd210a296333f6106c8c492d78ea12"
 dependencies = [
  "cfg-if",
  "libc",

--- a/client/graphics/Cargo.toml
+++ b/client/graphics/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2.60"
 log = "0.4"
-js-sys = "=0.3.36"
+js-sys = "=0.3.37"
 fern = "0.5.9"
 rand = "0.7"
 lazy_static = "1.4"

--- a/client/graphics/src/lib.rs
+++ b/client/graphics/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(allocator_api)]
+#![feature(global_allocator)]
 
 use rask_wasm_shared::{
     alloc::{settings::Graphics, Allocator, Initial},

--- a/client/logic/Cargo.toml
+++ b/client/logic/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2.60"
 log = "0.4"
-js-sys = "=0.3.36"
+js-sys = "=0.3.37"
 fern = "0.5.9"
 rand = "0.7"
 console_error_panic_hook = "0.1.6"

--- a/client/logic/src/lib.rs
+++ b/client/logic/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![feature(allocator_api)]
 #![feature(type_ascription)]
+#![feature(global_allocator)]
 
 use rask_wasm_shared::{
     alloc::{settings::Logic, Allocator, Initial},

--- a/client/shared/Cargo.toml
+++ b/client/shared/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 [dependencies]
 wasm-bindgen = "0.2.60"
 log = "0.4"
-js-sys = "=0.3.36"
+js-sys = "=0.3.37"
 fern = "0.5.9"
 rand = "0.7"
 image = "0.23"
@@ -44,4 +44,5 @@ features = [
 [dependencies.wee_alloc]
 version = "=0.4.5"
 features = ["size_classes", "static_array_backend", "nightly", "extra_assertions"]
-git = "https://github.com/squirrel-labs/wee_alloc"
+git = "https://github.com/Ma27/wee_alloc"
+branch = "nightly"

--- a/scripts/cargo-helpers.toml
+++ b/scripts/cargo-helpers.toml
@@ -3,12 +3,12 @@ BUILD_ENV = "debug"
 
 [tasks.exec-debug]
 command = "cargo"
-toolchain = "nightly-2020-02-28"
+toolchain = "nightly-2020-04-19"
 args = [ "${@}" ]
 workspace = false
 
 [tasks.exec-release]
 command = "cargo"
-toolchain = "nightly-2020-02-28"
+toolchain = "nightly-2020-04-19"
 args = [ "${@}", "--release" ]
 workspace = false

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
 { inCI ? false }:
 
 with import (fetchTarball {
-  url = https://github.com/NixOS/nixpkgs/archive/7a7952bce6c1e11a18831189ce4a97642013bf03.tar.gz;
-  sha256 = "17g76bkjh2dxwx4nbfksaydd4wkrcisa9sjfq1dhq11dzn7z2yh4";
+  url = https://github.com/NixOS/nixpkgs/archive/0657426ad90f0f940c5e296bd468e529cf159c6a.tar.gz;
+  sha256 = "1aw0d1892nywhj9xvf5rz4l974xw0wv43z9l9bfh28rwqrah73bf";
 }) { };
 
 mkShell {
@@ -20,5 +20,6 @@ mkShell {
     wasm-bindgen-cli
   ] ++ lib.optionals (!inCI) [
     cargo-audit
+    wabt
   ];
 }


### PR DESCRIPTION
Also needed another patch for `wee_alloc` (https://github.com/Ma27/wee_alloc/commit/0f9954eddcbd210a296333f6106c8c492d78ea12).

Todos before merging:

* [ ] consider creating a PR for `wee_alloc` to support latest nightly
* [ ] merging the `wee_alloc` patch into our fork (and give me push-access :p)
* [ ] tests/reviews to make sure my changes to the allocator API are at least somehow reasonable