### PR TITLE
Fix UB in Key

### DIFF
--- a/client/logic/src/game_context.rs
+++ b/client/logic/src/game_context.rs
@@ -115,9 +115,9 @@ impl GameContext {
     fn handle_message(&mut self, message: Message) -> Result<Option<Event>, ClientError> {
         match message {
             Message::KeyDown(modifier, hash) => {
-                Ok(Some(Event::KeyDown(modifier, Key::from_u8(hash))))
+                Ok(Some(Event::KeyDown(modifier, Key::from(hash))))
             }
-            Message::KeyUp(modifier, hash) => Ok(Some(Event::KeyUp(modifier, Key::from_u8(hash)))),
+            Message::KeyUp(modifier, hash) => Ok(Some(Event::KeyUp(modifier, Key::from(hash)))),
             Message::MouseDown(event) => Ok(Some(Event::MouseDown(event))),
             Message::MouseUp(event) => Ok(Some(Event::MouseUp(event))),
             Message::KeyPress(t, code) => Ok(Some(Event::KeyPress(t as u16, code))),

--- a/client/logic/src/game_context.rs
+++ b/client/logic/src/game_context.rs
@@ -114,9 +114,7 @@ impl GameContext {
     }
     fn handle_message(&mut self, message: Message) -> Result<Option<Event>, ClientError> {
         match message {
-            Message::KeyDown(modifier, hash) => {
-                Ok(Some(Event::KeyDown(modifier, Key::from(hash))))
-            }
+            Message::KeyDown(modifier, hash) => Ok(Some(Event::KeyDown(modifier, Key::from(hash)))),
             Message::KeyUp(modifier, hash) => Ok(Some(Event::KeyUp(modifier, Key::from(hash)))),
             Message::MouseDown(event) => Ok(Some(Event::MouseDown(event))),
             Message::MouseUp(event) => Ok(Some(Event::MouseUp(event))),

--- a/rask-engine/src/events.rs
+++ b/rask-engine/src/events.rs
@@ -1,18 +1,19 @@
 #![allow(clippy::unreadable_literal)]
-//! this module contains The game input/output event definiton
+//! this module contains The game input/output event definition
 
 #[derive(Debug, Clone, Copy)]
-#[repr(u32)]
-pub enum Key {
-    Unknown = 0,
-    A = 2335202,
-    Enter = 67114680,
+pub struct Key(u32);
+
+impl From<u32> for Key {
+    fn from(x: u32) -> Self {
+        Self(x)
+    }
 }
 
 impl Key {
-    pub fn from_u8(n: u32) -> Key {
-        unsafe { std::mem::transmute(n) }
-    }
+    pub const UNKNOWN: Key = Key(0);
+    pub const A: Key = Key(2335202);
+    pub const ENTER: Key = Key(67114680);
 }
 
 #[derive(Debug, Clone)]
@@ -27,16 +28,20 @@ pub enum Event {
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct KeyModifier(u8);
+
 impl KeyModifier {
     pub fn shift(self) -> bool {
         self.0 & 1 != 0
     }
+
     pub fn control(self) -> bool {
         self.0 & (1 << 1) != 0
     }
+
     pub fn alt(self) -> bool {
         self.0 & (1 << 2) != 0
     }
+
     pub fn meta(self) -> bool {
         self.0 & (1 << 3) != 0
     }
@@ -55,9 +60,11 @@ impl MouseEvent {
     pub fn left_mb(&self) -> bool {
         self.buttons & 1 != 0
     }
+
     pub fn right_mb(&self) -> bool {
         self.buttons & (1 << 1) != 0
     }
+
     pub fn middle_mb(&self) -> bool {
         self.buttons & (1 << 2) != 0
     }

--- a/rask-engine/src/resources/registry.rs
+++ b/rask-engine/src/resources/registry.rs
@@ -18,14 +18,14 @@ macro_rules! parse_resource {
 
 macro_rules! resources {
     ($(($name:ident, $variant:ident, $val:expr)),*) => {
-        resources! {0, $(($name, $variant, $val)),*}
+        resources! { 0, $(($name, $variant, $val)),* }
     };
     ($num:expr, ($name:ident, $variant:ident, $val:expr), $(($name2:ident, $variant2:ident, $val2:expr)),*) => {
-        parse_resource! {$num, $name, $variant, $val}
-        resources! {$num+1, $(($name2, $variant2, $val2)),*}
+        parse_resource! { $num, $name, $variant, $val }
+        resources! { $num+1, $(($name2, $variant2, $val2)),* }
     };
     ($num:expr, ($name:ident, $variant:ident, $val:expr)) => {
-        parse_resource! {$num, $name, $variant, $val}
+        parse_resource! { $num, $name, $variant, $val }
     };
 }
 

--- a/rask-engine/src/resources/resource_table.rs
+++ b/rask-engine/src/resources/resource_table.rs
@@ -10,6 +10,7 @@ macro_rules! character_check_helper {
     };
     ($enum_type: ident, $value: ident) => {};
 }
+
 macro_rules! get_store {
     ($type: ty, $enum_type: ident) => {
         impl GetStore<$type> for ResourceTable {
@@ -19,7 +20,7 @@ macro_rules! get_store {
                     Resource::$enum_type(value) => Ok(&value),
                     Resource::None => Err(EngineError::ResourceMissing(format!(
                         "Could not find requested recource #{}",
-                        id
+                        id,
                     ))),
                     res => {
                         #[allow(unused_variables)]
@@ -30,11 +31,12 @@ macro_rules! get_store {
                         }
                         Err(EngineError::ResourceType(format!(
                             "Wrong resource type, required \"{}\"",
-                            stringify!($type)
+                            stringify!($type),
                         )))
                     }
                 }
             }
+
             unsafe fn store(&mut self, data: $type, id: usize) -> Result<(), EngineError> {
                 self.index_check(id)?;
                 Ok(self.0[id] = Resource::$enum_type(data))
@@ -50,6 +52,7 @@ pub trait GetStore<T> {
     ///
     /// The function is not thread safe.
     unsafe fn get(&self, id: usize) -> Result<&T, EngineError>;
+
     /// Store a resource to the library
     ///
     /// # Safety


### PR DESCRIPTION
`Key` was defined as an enum with three variants and a `from_u8` method (that should have been named `from_u32`) that transmuted a `u32` to a `Key`:
```rust
#[repr(u32)]
pub enum Key {
    Unknown = 0,
    A = 2335202,
    Enter = 67114680,
}
```
That caused UB when the value was not one of 0, 2335202 or 67114680. This PR changes `Key` to a wrapper struct around a `u32`, with the variants becoming associated constants. `from_u32` is replaced with a `From<u32>` implementation.